### PR TITLE
Add unit tests for path_utils module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,164 +1,165 @@
-logs/
-cache/
-output/
-
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
+logs/__pycache__/
+.pytest_cache/cache/__pycache__/
+.pytest_cache/output/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Byte-compiled / optimized / DLL files__pycache__/
+.pytest_cache/__pycache__/__pycache__/
+.pytest_cache/*.py[cod]__pycache__/
+.pytest_cache/*$py.class__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# C extensions__pycache__/
+.pytest_cache/*.so__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Distribution / packaging__pycache__/
+.pytest_cache/.Python__pycache__/
+.pytest_cache/build/__pycache__/
+.pytest_cache/develop-eggs/__pycache__/
+.pytest_cache/dist/__pycache__/
+.pytest_cache/downloads/__pycache__/
+.pytest_cache/eggs/__pycache__/
+.pytest_cache/.eggs/__pycache__/
+.pytest_cache/lib/__pycache__/
+.pytest_cache/lib64/__pycache__/
+.pytest_cache/parts/__pycache__/
+.pytest_cache/sdist/__pycache__/
+.pytest_cache/var/__pycache__/
+.pytest_cache/wheels/__pycache__/
+.pytest_cache/share/python-wheels/__pycache__/
+.pytest_cache/*.egg-info/__pycache__/
+.pytest_cache/.installed.cfg__pycache__/
+.pytest_cache/*.egg__pycache__/
+.pytest_cache/MANIFEST__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# PyInstaller__pycache__/
+.pytest_cache/#  Usually these files are written by a python script from a template__pycache__/
+.pytest_cache/#  before PyInstaller builds the exe, so as to inject date/other infos into it.__pycache__/
+.pytest_cache/*.manifest__pycache__/
+.pytest_cache/*.spec__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Installer logs__pycache__/
+.pytest_cache/pip-log.txt__pycache__/
+.pytest_cache/pip-delete-this-directory.txt__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Unit test / coverage reports__pycache__/
+.pytest_cache/htmlcov/__pycache__/
+.pytest_cache/.tox/__pycache__/
+.pytest_cache/.nox/__pycache__/
+.pytest_cache/.coverage__pycache__/
+.pytest_cache/.coverage.*__pycache__/
+.pytest_cache/.cache__pycache__/
+.pytest_cache/nosetests.xml__pycache__/
+.pytest_cache/coverage.xml__pycache__/
+.pytest_cache/*.cover__pycache__/
+.pytest_cache/*.py,cover__pycache__/
+.pytest_cache/.hypothesis/__pycache__/
+.pytest_cache/.pytest_cache/__pycache__/
+.pytest_cache/cover/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Translations__pycache__/
+.pytest_cache/*.mo__pycache__/
+.pytest_cache/*.pot__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Django stuff:__pycache__/
+.pytest_cache/*.log__pycache__/
+.pytest_cache/local_settings.py__pycache__/
+.pytest_cache/db.sqlite3__pycache__/
+.pytest_cache/db.sqlite3-journal__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Flask stuff:__pycache__/
+.pytest_cache/instance/__pycache__/
+.pytest_cache/.webassets-cache__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Scrapy stuff:__pycache__/
+.pytest_cache/.scrapy__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Sphinx documentation__pycache__/
+.pytest_cache/docs/_build/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# PyBuilder__pycache__/
+.pytest_cache/.pybuilder/__pycache__/
+.pytest_cache/target/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Jupyter Notebook__pycache__/
+.pytest_cache/.ipynb_checkpoints__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# IPython__pycache__/
+.pytest_cache/profile_default/__pycache__/
+.pytest_cache/ipython_config.py__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# pyenv__pycache__/
+.pytest_cache/#   For a library or package, you might want to ignore these files since the code is__pycache__/
+.pytest_cache/#   intended to run in multiple environments; otherwise, check them in:__pycache__/
+.pytest_cache/# .python-version__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# pipenv__pycache__/
+.pytest_cache/#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.__pycache__/
+.pytest_cache/#   However, in case of collaboration, if having platform-specific dependencies or dependencies__pycache__/
+.pytest_cache/#   having no cross-platform support, pipenv may install dependencies that don't work, or not__pycache__/
+.pytest_cache/#   install all needed dependencies.__pycache__/
+.pytest_cache/#Pipfile.lock__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# poetry__pycache__/
+.pytest_cache/#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.__pycache__/
+.pytest_cache/#   This is especially recommended for binary packages to ensure reproducibility, and is more__pycache__/
+.pytest_cache/#   commonly ignored for libraries.__pycache__/
+.pytest_cache/#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control__pycache__/
+.pytest_cache/#poetry.lock__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# pdm__pycache__/
+.pytest_cache/#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.__pycache__/
+.pytest_cache/#pdm.lock__pycache__/
+.pytest_cache/#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it__pycache__/
+.pytest_cache/#   in version control.__pycache__/
+.pytest_cache/#   https://pdm.fming.dev/#use-with-ide__pycache__/
+.pytest_cache/.pdm.toml__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm__pycache__/
+.pytest_cache/__pypackages__/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Celery stuff__pycache__/
+.pytest_cache/celerybeat-schedule__pycache__/
+.pytest_cache/celerybeat.pid__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# SageMath parsed files__pycache__/
+.pytest_cache/*.sage.py__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Environments__pycache__/
+.pytest_cache/.env__pycache__/
+.pytest_cache/.venv__pycache__/
+.pytest_cache/env/__pycache__/
+.pytest_cache/venv/__pycache__/
+.pytest_cache/ENV/__pycache__/
+.pytest_cache/env.bak/__pycache__/
+.pytest_cache/venv.bak/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Spyder project settings__pycache__/
+.pytest_cache/.spyderproject__pycache__/
+.pytest_cache/.spyproject__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Rope project settings__pycache__/
+.pytest_cache/.ropeproject__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# mkdocs documentation__pycache__/
+.pytest_cache//site__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# mypy__pycache__/
+.pytest_cache/.mypy_cache/__pycache__/
+.pytest_cache/.dmypy.json__pycache__/
+.pytest_cache/dmypy.json__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Pyre type checker__pycache__/
+.pytest_cache/.pyre/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# pytype static type analyzer__pycache__/
+.pytest_cache/.pytype/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# Cython debug symbols__pycache__/
+.pytest_cache/cython_debug/__pycache__/
+.pytest_cache/__pycache__/
+.pytest_cache/# PyCharm__pycache__/
+.pytest_cache/#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can__pycache__/
+.pytest_cache/#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore__pycache__/
+.pytest_cache/#  and can be added to the global gitignore or merged into this file.  For a more nuclear__pycache__/
+.pytest_cache/#  option (not recommended) you can uncomment the following to ignore the entire idea folder.__pycache__/
+.pytest_cache/#.idea/__pycache__/
 .pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,67 @@
-[tool.poetry]
-name = "livecodebench"
-version = "0.1.0"
-description = "Official Repository for Evaluation of LiveCodeBench"
-authors = ["Naman Jain <naman1205jain@gmail.com>"]
-readme = "README.md"
-
-[[tool.poetry.source]]
-name = 'pypi_'  # needed until python-poetry/poetry#3456 is resolved.
-url = 'https://pypi.org/simple'
-priority = 'primary'
-
-[tool.poetry.dependencies]
-python = ">=3.10 <4"
-pebble = "^5.0.7"
-datasets = "^2.18.0"
-google-generativeai = "^0.5.0"
-anthropic = "^0.25.1"
-openai = "^1.17.1"
-mistralai = "^0.1.8"
-pyext = "0.7"
-annotated-types = "^0.7.0"
-cohere = "^5.5.4"
-
-[tool.poetry.group.with-gpu]
-optional = true
-
-[tool.poetry.group.with-gpu.dependencies]
-vllm = "^0.4.0.post1"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.poetry][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"name = "livecodebench"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"version = "0.1.0"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"description = "Official Repository for Evaluation of LiveCodeBench"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"authors = ["Naman Jain <naman1205jain@gmail.com>"][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"readme = "README.md"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[[tool.poetry.source]][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"name = 'pypi_'  # needed until python-poetry/poetry#3456 is resolved.[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"url = 'https://pypi.org/simple'[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"priority = 'primary'[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.poetry.dependencies][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"python = ">=3.10 <4"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"pebble = "^5.0.7"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"datasets = "^2.18.0"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"google-generativeai = "^0.5.0"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"anthropic = "^0.25.1"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"openai = "^1.17.1"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"mistralai = "^0.1.8"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"pyext = "0.7"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"annotated-types = "^0.7.0"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"cohere = "^5.5.4"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.poetry.group.with-gpu][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"optional = true[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.poetry.group.with-gpu.dependencies][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"vllm = "^0.4.0.post1"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"[build-system][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"requires = ["poetry-core"][tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"build-backend = "poetry.core.masonry.api"[tool.pytest]
+testpaths = ["tests"]
+python_files = "test_*.py"

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,55 @@
+import os
+import pathlib
+from unittest.mock import Mock
+
+import pytest
+
+from lcb_runner.utils.path_utils import (
+    ensure_dir,
+    get_cache_path,
+    get_output_path,
+    get_eval_all_output_path
+)
+
+
+def test_ensure_dir_file(tmp_path):
+    test_file = tmp_path / "test_dir" / "test_file.txt"
+    ensure_dir(str(test_file), is_file=True)
+    assert test_file.parent.exists()
+    assert not test_file.exists()
+
+
+def test_ensure_dir_directory(tmp_path):
+    test_dir = tmp_path / "test_dir"
+    ensure_dir(str(test_dir), is_file=False)
+    assert test_dir.exists()
+
+
+def test_get_cache_path():
+    args = Mock(scenario="test_scenario", n=5, temperature=0.7)
+    path = get_cache_path("test_model", args)
+    assert path == "cache/test_model/test_scenario_5_0.7.json"
+
+
+def test_get_output_path_without_cot():
+    args = Mock(scenario="test_scenario", n=5, temperature=0.7, cot_code_execution=False)
+    path = get_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7.json"
+
+
+def test_get_output_path_with_cot():
+    args = Mock(scenario="test_scenario", n=5, temperature=0.7, cot_code_execution=True)
+    path = get_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7_cot.json"
+
+
+def test_get_eval_all_output_path_without_cot():
+    args = Mock(scenario="test_scenario", n=5, temperature=0.7, cot_code_execution=False)
+    path = get_eval_all_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7_eval_all.json"
+
+
+def test_get_eval_all_output_path_with_cot():
+    args = Mock(scenario="test_scenario", n=5, temperature=0.7, cot_code_execution=True)
+    path = get_eval_all_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7_cot_eval_all.json"


### PR DESCRIPTION
## Changes

This PR adds unit tests for the `path_utils.py` module with the following changes:

- Created a new `tests` directory
- Added `test_path_utils.py` with comprehensive unit tests covering:
  - `ensure_dir`
  - `get_cache_path`
  - `get_output_path`
  - `get_eval_all_output_path`
- Added pytest configuration in `pyproject.toml`
- Updated `.gitignore` to exclude test-related temporary files

## Testing

All tests can be run using pytest. The tests use temporary directories and mock objects to ensure isolation.