### PR TITLE
Add unit tests for parser.py

### DIFF
--- a/lcb_runner/runner/test_parser.py
+++ b/lcb_runner/runner/test_parser.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+from lcb_runner.runner.parser import get_args
+
+class TestParser(unittest.TestCase):
+
+    @patch('argparse._sys.argv', ['parser.py', '--model', 'gpt-4', '--n', '5'])
+    def test_get_args_default(self):
+        args = get_args()
+        self.assertEqual(args.model, 'gpt-4')
+        self.assertEqual(args.n, 5)
+
+    @patch('argparse._sys.argv', ['parser.py', '--temperature', '0.5', '--top_p', '0.9'])
+    def test_get_args_sampling(self):
+        args = get_args()
+        self.assertEqual(args.temperature, 0.5)
+        self.assertEqual(args.top_p, 0.9)
+
+    @patch('argparse._sys.argv', ['parser.py', '--enable_prefix_caching'])
+    def test_get_args_flags(self):
+        args = get_args()
+        self.assertTrue(args.enable_prefix_caching)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds unit tests for the `get_args` function in the `lcb_runner/runner/` directory. Changes include:

- Created a new file `test_parser.py` in the `lcb_runner/runner/` directory
- Added `TestParser` class with three test methods:
  1. `test_get_args_default`: Tests default argument parsing
  2. `test_get_args_sampling`: Tests parsing of sampling-related arguments
  3. `test_get_args_flags`: Tests parsing of boolean flags
- Used `unittest.mock.patch` to simulate command-line arguments
- Ensured correct import of `get_args` function from `lcb_runner.runner.parser`

These tests will improve the reliability and maintainability of the argument parsing functionality in the project.