### PR TITLE
Add unit tests for path_utils.py

### DIFF
--- a/lcb_runner/tests/__init__.py
+++ b/lcb_runner/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package initialization

--- a/lcb_runner/tests/utils/__init__.py
+++ b/lcb_runner/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils test package initialization

--- a/lcb_runner/tests/utils/test_path_utils.py
+++ b/lcb_runner/tests/utils/test_path_utils.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+from pathlib import Path
+
+from lcb_runner.utils.path_utils import (
+    ensure_dir,
+    get_cache_path,
+    get_output_path,
+    get_eval_all_output_path
+)
+
+def test_ensure_dir_file(tmp_path):
+    test_file = tmp_path / "test_dir" / "test_file.txt"
+    ensure_dir(str(test_file), is_file=True)
+    assert test_file.parent.exists()
+    assert not test_file.exists()
+
+def test_ensure_dir_directory(tmp_path):
+    test_dir = tmp_path / "test_dir"
+    ensure_dir(str(test_dir), is_file=False)
+    assert test_dir.exists()
+    assert test_dir.is_dir()
+
+def test_get_cache_path():
+    args = type('Args', (), {
+        'scenario': 'test_scenario',
+        'n': 5,
+        'temperature': 0.7
+    })()
+    
+    path = get_cache_path("test_model", args)
+    assert path == "cache/test_model/test_scenario_5_0.7.json"
+
+def test_get_output_path_without_cot():
+    args = type('Args', (), {
+        'scenario': 'test_scenario',
+        'n': 5,
+        'temperature': 0.7,
+        'cot_code_execution': False
+    })()
+    
+    path = get_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7.json"
+
+def test_get_output_path_with_cot():
+    args = type('Args', (), {
+        'scenario': 'test_scenario',
+        'n': 5,
+        'temperature': 0.7,
+        'cot_code_execution': True
+    })()
+    
+    path = get_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7_cot.json"
+
+def test_get_eval_all_output_path_without_cot():
+    args = type('Args', (), {
+        'scenario': 'test_scenario',
+        'n': 5,
+        'temperature': 0.7,
+        'cot_code_execution': False
+    })()
+    
+    path = get_eval_all_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7_eval_all.json"
+
+def test_get_eval_all_output_path_with_cot():
+    args = type('Args', (), {
+        'scenario': 'test_scenario',
+        'n': 5,
+        'temperature': 0.7,
+        'cot_code_execution': True
+    })()
+    
+    path = get_eval_all_output_path("test_model", args)
+    assert path == "output/test_model/test_scenario_5_0.7_cot_eval_all.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "livecodebench"
 version = "0.1.0"
 description = "Official Repository for Evaluation of LiveCodeBench"
-authors = ["Naman Jain <naman1205jain@gmail.com>"]
+authors = ["Naman Jain &lt;naman1205jain@gmail.com&gt;"]
 readme = "README.md"
 
 [[tool.poetry.source]]
@@ -11,7 +11,11 @@ url = 'https://pypi.org/simple'
 priority = 'primary'
 
 [tool.poetry.dependencies]
-python = ">=3.10 <4"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0.0"
+pytest-mock = "^3.0.0"
+python = "&gt;=3.10 &lt;4"
 pebble = "^5.0.7"
 datasets = "^2.18.0"
 google-generativeai = "^0.5.0"


### PR DESCRIPTION
This PR adds comprehensive unit tests for the path_utils.py module and sets up the testing infrastructure. Changes include:

- Created test directory structure with proper `__init__.py` files
- Added `test_path_utils.py` with test coverage for all path utility functions:
  - `ensure_dir`
  - `get_cache_path`
  - `get_output_path`
  - `get_eval_all_output_path`
- Added pytest dependencies to `pyproject.toml`:
  - pytest ^7.0.0
  - pytest-mock ^3.0.0

The tests verify path generation logic and directory creation functionality using pytest's tmp_path fixture for safe filesystem operations.